### PR TITLE
first stub at adding the paste json-schema on creating a resource

### DIFF
--- a/src/app/api/NewResource.js
+++ b/src/app/api/NewResource.js
@@ -1,225 +1,331 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { Button, Card, Input } from 'turtle-ui';
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { Button, Card, Input, TextArea } from "turtle-ui";
 
-import Machinable from '../../client';
-import Statics from '../../Statics';
-import slugify from 'slugify';
-import ObjectComponent from './editor/Object';
+import Machinable from "../../client";
+import Statics from "../../Statics";
+import slugify from "slugify";
+import ObjectComponent from "./editor/Object";
 
 class NewResource extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: true,
+      slug: props.slug,
+      navSelection: { text: "Form", render: this.renderForm },
+      loadSchema: false,
+      jsonschema: "",
+      newResource: {
+        errors: [],
+        title: "",
+        path_name: "",
+        schema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+    };
+  }
 
-	constructor(props) {
-		super(props);
-		this.state = {
-			loading: true,
-			slug: props.slug,
-            navSelection: {text: "Form", render: this.renderForm},
-			newResource: {
-				errors: [],
-				title: "",
-				path_name: "",
-				schema: {
-                    type: "object",
-                    properties: {},
-                    required: []
-                },
-            }
-		}
-	}
+  onPropertiesChange = (newValue, event) => {
+    // var schema = this.state.c;
+    // schema = newValue;
+    // try{
+    //     var temp = JSON.parse(value);
+    //     temp = JSON.stringify(temp, undefined, 4);
+    //     value = temp;
+    // }catch(err){}
+    // this.setState({
+    // 	schema: schema
+    // });
+  };
 
-	onPropertiesChange = (newValue, event) => {
-		// var schema = this.state.c;
-        // schema = newValue;
-        
-        // try{
-        //     var temp = JSON.parse(value);
-        //     temp = JSON.stringify(temp, undefined, 4);
-        //     value = temp;
-        // }catch(err){}
+  onChange = (event) => {
+    const target = event.target;
+    var value = target.value;
+    const name = target.name;
 
-		// this.setState({
-		// 	schema: schema
-		// });
-	}
+    var newResource = this.state.newResource;
 
-	onChange = (event) => {
-	    const target = event.target;
-	    var value = target.value;
-	    const name = target.name;
-
-		var newResource = this.state.newResource;
-		
-		if (name === "title") {
-			newResource["path_name"] = value;
-		} 
-		else if (name === "path_name") {
-			var vals = value.split("/")
-			if (vals.length > 1) {
-				value = value.split("/")[1];
-			}
-		}
-
-		newResource[name] = value;
-
-		// slugify path name
-		newResource["path_name"] = slugify(newResource["path_name"], {
-										replacement: '-',
-										remove: null,  
-										lower: false
-									});
-
-	    this.setState({
-	    	newResource: newResource
-	    });
-	}
-
-	saveError = (response) => {
-		console.log(response);
-
-        var newResource = this.state.newResource;
-        var error = response.data && response.data.error ? response.data.error : "unknown error";
-		newResource.errors.push(error);
-
-		this.setState({
-			newResource: newResource
-		});
-	}
-
-	saveSuccess = (response) => {
-        this.setState({
-            newResource: {
-				errors: [],
-				title: "",
-				path_name: "",
-				schema: {
-                    type: "object",
-                    properties: {},
-                    required: []
-                },
-            }
-        })
-        this.props.onSuccess(response);
-	}
-
-	saveResource = () => {
-		var errors = [];
-		var newResource = this.state.newResource;
-		newResource.errors = [];
-		this.setState({
-			newResource: newResource
-		});
-		if (newResource.title === "") {
-			errors.push("Resource title cannot be empty.");
-		}
-		if (newResource.path_name === "") {
-			errors.push("Resource path cannot be empty.");
-		}
-		if (newResource.schema === undefined) {
-			errors.push("A resource must have a defined schema.");
-		}
-
-		if (errors.length > 0) {
-			newResource.errors = errors;
-			this.setState({
-				newResource: newResource
-			});
-			return;
-		}
-
-        // remove _sort key for visual
-        let scrubSchema = JSON.parse(JSON.stringify(this.state.newResource.schema))
-        scrubSchema.properties = this.removeKey("_sort", scrubSchema.properties)
-		var payload = {
-			"title": newResource.title,
-			"path_name": newResource.path_name,
-			"schema": scrubSchema
-		};
-
-		Machinable.resources(this.state.slug).create(payload, this.saveSuccess, this.saveError)
+    if (name === "title") {
+      newResource["path_name"] = value;
+    } else if (name === "path_name") {
+      var vals = value.split("/");
+      if (vals.length > 1) {
+        value = value.split("/")[1];
+      }
     }
 
-    onUpdate = (key, obj) => {
-        let newResource = this.state.newResource;
-        newResource.schema.properties = obj.properties;
-        this.setState({
-            newResource: newResource
-        });
+    newResource[name] = value;
+
+    // slugify path name
+    newResource["path_name"] = slugify(newResource["path_name"], {
+      replacement: "-",
+      remove: null,
+      lower: false,
+    });
+
+    this.setState({
+      newResource: newResource,
+    });
+  };
+
+  saveError = (response) => {
+    console.log(response);
+
+    var newResource = this.state.newResource;
+    var error =
+      response.data && response.data.error
+        ? response.data.error
+        : "unknown error";
+    newResource.errors.push(error);
+
+    this.setState({
+      newResource: newResource,
+    });
+  };
+
+  saveSuccess = (response) => {
+    this.setState({
+      newResource: {
+        errors: [],
+        title: "",
+        path_name: "",
+        schema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+    });
+    this.props.onSuccess(response);
+  };
+
+  saveResource = () => {
+    var errors = [];
+    var newResource = this.state.newResource;
+    newResource.errors = [];
+    this.setState({
+      newResource: newResource,
+    });
+    if (newResource.title === "") {
+      errors.push("Resource title cannot be empty.");
     }
-    
-	toggleNav = (link) => {
-        this.setState({navSelection: link});
+    if (newResource.path_name === "") {
+      errors.push("Resource path cannot be empty.");
+    }
+    if (newResource.schema === undefined) {
+      errors.push("A resource must have a defined schema.");
     }
 
-    removeKey = (key, obj) => {
-        for(var k in obj) {
-            delete obj[k][key];
-            if(obj[k].type === "object") {
-                obj[k].properties = this.removeKey(key, obj[k].properties)
-            }
-        }
-        return obj
+    if (errors.length > 0) {
+      newResource.errors = errors;
+      this.setState({
+        newResource: newResource,
+      });
+      return;
     }
 
-    renderForm = () => {
-        return (
-            <ObjectComponent onUpdate={this.onUpdate} property={this.state.newResource.schema} />
-        );
+    // remove _sort key for visual
+    let scrubSchema = JSON.parse(JSON.stringify(this.state.newResource.schema));
+    scrubSchema.properties = this.removeKey("_sort", scrubSchema.properties);
+    var payload = {
+      title: newResource.title,
+      path_name: newResource.path_name,
+      schema: scrubSchema,
+    };
+
+    Machinable.resources(this.state.slug).create(
+      payload,
+      this.saveSuccess,
+      this.saveError
+    );
+  };
+
+  onUpdate = (key, obj) => {
+    let newResource = this.state.newResource;
+    newResource.schema.properties = obj.properties;
+    this.setState({
+      newResource: newResource,
+    });
+  };
+
+  toggleNav = (link) => {
+    this.setState({ navSelection: link });
+  };
+
+  removeKey = (key, obj) => {
+    for (var k in obj) {
+      delete obj[k][key];
+      if (obj[k].type === "object") {
+        obj[k].properties = this.removeKey(key, obj[k].properties);
+      }
     }
+    return obj;
+  };
 
-	render() {
+  renderForm = () => {
+    console.log(this.state.newResource);
+    return (
+      <ObjectComponent
+        onUpdate={this.onUpdate}
+        property={this.state.newResource.schema}
+      />
+    );
+  };
 
-		return (
-            <div className="full-height grid grid-5">
-                <div className="col-3-5 grid-column-end-6">
-                    <div className="grid grid-1">
-                        <Card 
-                            classes="footer-plain no-border"
-                            footer={
-                                <div className="grid grid-2">
-                                    <div className="col-2 col-right">
-                                        <Button classes="accent" onClick={this.saveResource}>Save</Button>	
-                                        <Button classes="plain text" onClick={this.props.close}>Cancel</Button>	
-                                    </div>
-                                </div>
-                            }>
-                            <div className="modal-header">
-                                <h2 className="text-400 margin-bottom no-margin-top">Create a resource</h2>
-                                <p className="text-muted margin-top margin-bottom-even-more">Configure an API Resource to store structured data</p>
-                            </div>
-                            <div className="grid grid-1">
-                                {this.state.newResource.errors.length > 0 &&
-                                    <div className="text-danger">
-                                        {this.state.newResource.errors.map(function(error, i){
-                                            return(
-                                                <div key={i}>{error}</div>
-                                            )
-                                        })}
-                                    </div>
-                                }
-                                
-                                <Input placeholder="descriptive title of the resource" label="Title" name="title" value={this.state.newResource.title} onChange={this.onChange}/>
-                                <Input placeholder="the url path of this resource" label="Path" name="path_name" value={"/" + this.state.newResource.path_name} onChange={this.onChange}/>
-                                <strong>Schema</strong>
-                                <div className="margin-top-less text-medium text-muted">
-                                    Define your resource properties using <a className="link text-400 text-information" target="_blank" rel="noopener noreferrer" href="https://json-schema.org/">JSON Schema</a>. 
-                                    Check out our <a className="link text-400 text-information" target="_blank" rel="noopener noreferrer" href={Statics.DOCS.JSON_SCHEMA_SAMPLES}>sample schemas</a> to get an idea of how to structure your data.
-                                </div>
-                                {this.renderForm()}
-                            </div>
-                        </Card>
-                    </div>
+  render() {
+    return (
+      <div className="full-height grid grid-5">
+        <div className="col-3-5 grid-column-end-6">
+          <div className="grid grid-1">
+            <Card
+              classes="footer-plain no-border"
+              footer={
+                <div className="grid grid-2">
+                  <div className="col-2 col-right">
+                    <Button classes="accent" onClick={this.saveResource}>
+                      Save
+                    </Button>
+                    <Button classes="plain text" onClick={this.props.close}>
+                      Cancel
+                    </Button>
+                  </div>
                 </div>
-            </div>
-		  );
-	}
+              }
+            >
+              <div className="modal-header">
+                <h2 className="text-400 margin-bottom no-margin-top">
+                  Create a resource
+                </h2>
+                <p className="text-muted margin-top margin-bottom-even-more">
+                  Configure an API Resource to store structured data
+                </p>
+              </div>
+              <div className="grid grid-1">
+                {this.state.newResource.errors.length > 0 && (
+                  <div className="text-danger">
+                    {this.state.newResource.errors.map(function (error, i) {
+                      return <div key={i}>{error}</div>;
+                    })}
+                  </div>
+                )}
+
+                <Input
+                  placeholder="descriptive title of the resource"
+                  label="Title"
+                  name="title"
+                  value={this.state.newResource.title}
+                  onChange={this.onChange}
+                />
+                <Input
+                  placeholder="the url path of this resource"
+                  label="Path"
+                  name="path_name"
+                  value={"/" + this.state.newResource.path_name}
+                  onChange={this.onChange}
+                />
+                <strong>Schema</strong>
+                <div className="margin-top-less text-medium text-muted">
+                  Define your resource properties using{" "}
+                  <a
+                    className="link text-400 text-information"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://json-schema.org/"
+                  >
+                    JSON Schema
+                  </a>
+                  . Check out our{" "}
+                  <a
+                    className="link text-400 text-information"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={Statics.DOCS.JSON_SCHEMA_SAMPLES}
+                  >
+                    sample schemas
+                  </a>{" "}
+                  to get an idea of how to structure your data.
+                </div>
+                {!this.state.loadSchema && (
+                  <Button
+                    classes="brand plain margin-top  btn-small"
+                    onClick={() =>
+                      this.setState({ ...this.state, loadSchema: true })
+                    }
+                  >
+                    Load Json Schema
+                  </Button>
+                )}
+                {this.state.loadSchema && (
+                  <div>
+                    <TextArea
+                      label="Json Schema to load"
+                      name="jsonschema"
+                      placeholder="Json Schema to load"
+                      value={this.state.jsonschema}
+                      onChange={(event) => {
+                        this.setState({
+                          ...this.state,
+                          jsonschema: event.target.value,
+                        });
+                      }}
+                    />
+                    <Button
+                      classes="brand plain margin-top  btn-small"
+                      onClick={() => {
+                        try {
+                          let schema = JSON.parse(this.state.jsonschema);
+                          const defaultSchema = {
+                            type: "object",
+                            properties: {},
+                            required: [],
+                          };
+                          schema = {
+                            ...defaultSchema,
+                            properties:
+                              schema.properties || defaultSchema.properties,
+                            required: schema.required || [],
+                          };
+                          this.setState({
+                            ...this.state,
+                            jsonschema: "",
+                            newResource: {
+                              ...this.state.newResource,
+                              schema: schema,
+                            },
+                            loadSchema: false,
+                          });
+                        } catch (e) {
+                          console.log(e);
+                          this.setState({
+                            ...this.state,
+                            loadSchema: false,
+                          });
+                        }
+                      }}
+                    >
+                      Load Json Schema
+                    </Button>
+                  </div>
+                )}
+                {this.renderForm()}
+              </div>
+            </Card>
+          </div>
+        </div>
+      </div>
+    );
+  }
 }
 
 // redux
 function mapStateToProps(state) {
-	return {
-		slug: state.project_slug
-	};
+  return {
+    slug: state.project_slug,
+  };
 }
-  
+
 export default connect(mapStateToProps)(NewResource);


### PR DESCRIPTION
In the demo notes app you created you showed a json-schema that is needed to make it able to work. The issue is that you can create the schema just with the UI and it can take a while (in that case is pretty simple) so I've added a way to paste a json schema that automatically generates the fields.
Here's a demo, it is still a work in progress.
![Peek 2020-06-16 19-20](https://user-images.githubusercontent.com/200319/84807067-f4b4bf80-b006-11ea-908b-a3896928985f.gif)

The PR looks a bit of a mess because I have prettier enabled in my editor (i thought almost everyone was using it these days, I'll fix that and comply to your style)